### PR TITLE
Bump go version to 1.12

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,5 +6,5 @@ applications:
    instances: 2
    buildpack: go_buildpack
    env:
-     GOVERSION: go1.10
+     GOVERSION: go1.12
      GOPACKAGENAME: github.com/alext/cf_basic_auth_route_service


### PR DESCRIPTION
Current version 1.10 no longer builds on Gov.uk PaaS so bumping up to 1.12. Reason for 1.12 is 1.11 is going to be retired soon.

```
-> % cf start example-auth
Starting app example-auth in org SOMETHING / space SOMETHING as me@myemail...

Staging app and tracing logs...
   Downloading go_buildpack...
   Downloaded go_buildpack
   Cell CELL creating container for instance ID
   Cell CELL successfully created container for instance ID
   Downloading app package...
   Downloaded app package (9.3M)
   -----> Go Buildpack version 1.8.42
          **WARNING** [DEPRECATION WARNING]:
          **WARNING** Please use AppDynamics extension buildpack for Golang Application instrumentation
          **WARNING** for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html
   -----> Installing godep 80
          Download [https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz]
   -----> Installing glide 0.13.3
          Download [https://buildpacks.cloudfoundry.org/dependencies/glide/glide-v0.13.3-linux-x64-cflinuxfs3-ef07acb5.tgz]
   -----> Installing dep 0.5.4
          Download [https://buildpacks.cloudfoundry.org/dependencies/dep/dep-v0.5.4-linux-x64-cflinuxfs3-79b3ab9e.tgz]
          **ERROR** Unable to determine Go version to install: no match found for 1.10.x in [1.11.11 1.11.12 1.12.6 1.12.7]
   Failed to compile droplet: Failed to run all supply scripts: exit status 16
   Exit status 223
   Cell CELL stopping instance ID
   Cell CELL destroying container for instance ID
Error staging application: App staging failed in the buildpack compile phase
FAILED
```